### PR TITLE
技巧：gdb退出时不显示提示信息

### DIFF
--- a/src/Don't-show-confirmation-prompt-when-quitting-gdb.md
+++ b/src/Don't-show-confirmation-prompt-when-quitting-gdb.md
@@ -1,0 +1,24 @@
+# gdb退出时不显示提示信息
+
+## 例子
+gdb在退出时会提示:  
+
+	A debugging session is active.
+
+        Inferior 1 [process 29686    ] will be killed.
+
+    Quit anyway? (y or n) n
+
+
+## 技巧
+
+如果不想显示这个信息，则可以在gdb中使用如下命令把提示信息关掉:
+
+	(gdb) set confirm off
+
+也可以把这个命令加到.gdbinit文件里。
+
+## 贡献者
+
+nanxiao
+


### PR DESCRIPTION
技巧：gdb退出时不显示提示信息
