### PR TITLE
pretty-printer already registered

### DIFF
--- a/src/print-STL-container.md
+++ b/src/print-STL-container.md
@@ -36,13 +36,23 @@ gdb 7.0之后，可以使用gcc提供的python脚本，来改善显示结果：
 	(gdb) p vec
 	$1 = std::vector of length 10, capacity 10 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 
+某些发行版(Fedora 11+)，不需要额外的设置工作。可在gdb命令行下验证（若没有显示，可按下文的方法进行设置）。
+
+		(gdb) info pretty-printer
+
 方法如下:
 
-1. 获得最新的python脚本
+1. 获得python脚本，建议使用gcc默认安装的
+
+		sudo find / -name "*libstdcxx*"
+2. 若本机查找不到python脚本，建议下载gcc对应版本源码包，相对目录如下
+
+		gcc-4.8.1/libstdc++-v3/python
+3. 也可直接下载最新版本
 
 		svn co svn://gcc.gnu.org/svn/gcc/trunk/libstdc++-v3/python
 
-2. 将如下代码添加到.gdbinit文件中（假设python脚本位于 /home/maude/gdb_printers/ 下）
+4. 将如下代码添加到.gdbinit文件中（假设python脚本位于 /home/maude/gdb_printers/ 下）
 
 		python
 		import sys
@@ -66,3 +76,4 @@ xmj
 
 xanpeng
 
+enjolras


### PR DESCRIPTION
env:
centos6.5 编译安装gcc4.8.1 gdb7.6

detail:
设置前 info pretty-printer 显示为空的情况下，使用最新版本的python脚本报：pretty-printer already registered。
目录改为/usr/local/share/gcc-4.8.1/python/之后无报错。