### PR TITLE
新增“打印所有线程的堆栈信息”并修改一个C代码bug

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -65,6 +65,7 @@
 * [调试子进程](set-follow-fork-mode-child.md)
 * [同时调试父进程和子进程](set-detach-on-fork.md)
 * [查看线程信息](print-threads.md)
+* [打印所有线程的堆栈信息](print-all-threads-bt.md)
 * [在Solaris上使用maintenance命令查看线程信息](maint-info-sol-threads.md)
 * [不显示线程启动和退出信息](show-print-thread-events.md)
 * [只允许一个线程运行](set-scheduler-locking-on.md)

--- a/src/print-all-threads-bt.md
+++ b/src/print-all-threads-bt.md
@@ -1,0 +1,73 @@
+# 打印所有线程的堆栈信息
+## 例子
+	#include <stdio.h>
+	#include <pthread.h>
+	#include <unistd.h>
+	int a = 0;
+
+	void *thread1_func(void *p_arg)
+	{
+	        while (1)
+	        {
+	                a++;
+	                sleep(10);
+	        }
+	}
+
+	int main(int argc, char* argv[])
+	{
+	        pthread_t t1, t2;
+	        pthread_create(&t1, NULL, thread1_func, NULL);
+	        pthread_create(&t2, NULL, thread1_func, NULL);
+
+	        sleep(1000);
+	        return 0;
+	}
+
+## 技巧
+gdb可以使用“`thread apply all bt`”命令打印所有线程的堆栈信息。以上面程序为例:
+
+    (gdb) thread apply all bt
+
+    Thread 3 (Thread -1210868832 (LWP 26975)):
+    #0  0xb7dcc96c in __gxx_personality_v0 () from /lib/libc.so.6
+    #1  0xb7dcc77f in sleep () from /lib/libc.so.6
+    #2  0x08048575 in thread1_func ()
+    #3  0xb7e871eb in start_thread () from /lib/libpthread.so.0
+    #4  0xb7e007fe in clone () from /lib/libc.so.6
+
+    Thread 2 (Thread -1219257440 (LWP 26976)):
+    #0  0xb7dcc96c in __gxx_personality_v0 () from /lib/libc.so.6
+    #1  0xb7dcc77f in sleep () from /lib/libc.so.6
+    #2  0x08048575 in thread1_func ()
+    #3  0xb7e871eb in start_thread () from /lib/libpthread.so.0
+    #4  0xb7e007fe in clone () from /lib/libc.so.6
+
+    Thread 1 (Thread -1210866000 (LWP 26974)):
+    #0  0xb7dcc96c in __gxx_personality_v0 () from /lib/libc.so.6
+    #1  0xb7dcc77f in sleep () from /lib/libc.so.6
+    #2  0x08048547 in main ()
+    #0  0xb7dcc96c in __gxx_personality_v0 () from /lib/libc.so.6
+
+可以看到，使用“`thread apply all bt`”命令以后，会对所有的线程实施backtrace命令。`thread apply [thread-id-list] [all] args` 也可以对指定的线程ID列表进行执行：
+
+    (gdb) thread apply 1-2 bt
+
+    Thread 1 (Thread -1210866000 (LWP 26974)):
+    #0  0xb7dcc96c in __gxx_personality_v0 () from /lib/libc.so.6
+    #1  0xb7dcc77f in sleep () from /lib/libc.so.6
+    #2  0x08048547 in main ()
+
+    Thread 2 (Thread -1219257440 (LWP 26976)):
+    #0  0xb7dcc96c in __gxx_personality_v0 () from /lib/libc.so.6
+    #1  0xb7dcc77f in sleep () from /lib/libc.so.6
+    #2  0x08048575 in thread1_func ()
+    #3  0xb7e871eb in start_thread () from /lib/libpthread.so.0
+    #4  0xb7e007fe in clone () from /lib/libc.so.6
+    #0  0xb7dcc96c in __gxx_personality_v0 () from /lib/libc.so.6
+
+`thread apply`更多用法和`thread-id-list`的格式用法参见[gdb手册](https://sourceware.org/gdb/onlinedocs/gdb/Threads.html).
+
+## 贡献者
+
+panzhongxian

--- a/src/set-watchpoint.md
+++ b/src/set-watchpoint.md
@@ -4,7 +4,7 @@
 	#include <pthread.h>
 	#include <unistd.h>
 	int a = 0;
-	
+
 	void *thread1_func(void *p_arg)
 	{
 	        while (1)
@@ -13,26 +13,26 @@
 	                sleep(10);
 	        }
 	}
-	
+
 	int main(int argc, char* argv[])
 	{
 	        pthread_t t1;
-	
-	        pthread_create(&t1, NULL, thread1_func, "Thread 1");
-			
+            char thread_name[] = "Thread 1";
+	        pthread_create(&t1, NULL, thread1_func, thread_name);
+
 	        sleep(1000);
 	        return 0;
 	}
 
 ## 技巧
-gdb可以使用“`watch`”命令设置观察点，也就是当一个变量值发生变化时，程序会停下来。以上面程序为例:  
+gdb可以使用“`watch`”命令设置观察点，也就是当一个变量值发生变化时，程序会停下来。以上面程序为例:
 
 	(gdb) start
 	Temporary breakpoint 1 at 0x4005a8: file a.c, line 19.
 	Starting program: /data2/home/nanxiao/a
 	[Thread debugging using libthread_db enabled]
 	Using host libthread_db library "/lib64/libthread_db.so.1".
-	
+
 	Temporary breakpoint 1, main () at a.c:19
 	19              pthread_create(&t1, NULL, thread1_func, "Thread 1");
 	(gdb) watch a
@@ -44,7 +44,7 @@ gdb可以使用“`watch`”命令设置观察点，也就是当一个变量值�
 	[New Thread 0x7ffff782c700 (LWP 8813)]
 	[Switching to Thread 0x7ffff782c700 (LWP 8813)]
 	Hardware watchpoint 2: a
-	
+
 	Old value = 0
 	New value = 1
 	thread1_func (p_arg=0x4006d8) at a.c:11
@@ -52,14 +52,14 @@ gdb可以使用“`watch`”命令设置观察点，也就是当一个变量值�
 	(gdb) c
 	Continuing.
 	Hardware watchpoint 2: a
-	
+
 	Old value = 1
 	New value = 2
 	thread1_func (p_arg=0x4006d8) at a.c:11
 	11                      sleep(10);
 
-可以看到，使用“`watch a`”命令以后，当`a`的值变化：由`0`变成`1`，由`1`变成`2`，程序都会停下来。  
-此外也可以使用“`watch *(data type*)address`”这样的命令，仍以上面程序为例:  
+可以看到，使用“`watch a`”命令以后，当`a`的值变化：由`0`变成`1`，由`1`变成`2`，程序都会停下来。
+此外也可以使用“`watch *(data type*)address`”这样的命令，仍以上面程序为例:
 
 	(gdb) p &a
 	$1 = (int *) 0x6009c8 <a>
@@ -72,7 +72,7 @@ gdb可以使用“`watch`”命令设置观察点，也就是当一个变量值�
 	[New Thread 0x7ffff782c700 (LWP 15431)]
 	[Switching to Thread 0x7ffff782c700 (LWP 15431)]
 	Hardware watchpoint 2: *(int*)0x6009c8
-	
+
 	Old value = 0
 	New value = 1
 	thread1_func (p_arg=0x4006d8) at a.c:11
@@ -80,24 +80,24 @@ gdb可以使用“`watch`”命令设置观察点，也就是当一个变量值�
 	(gdb) c
 	Continuing.
 	Hardware watchpoint 2: *(int*)0x6009c8
-	
+
 	Old value = 1
 	New value = 2
 	thread1_func (p_arg=0x4006d8) at a.c:11
 	11                      sleep(10);
 
-先得到`a`的地址：`0x6009c8`，接着用“`watch *(int*)0x6009c8`”设置观察点，可以看到同“`watch a`”命令效果一样。  
+先得到`a`的地址：`0x6009c8`，接着用“`watch *(int*)0x6009c8`”设置观察点，可以看到同“`watch a`”命令效果一样。
 观察点可以通过软件或硬件的方式实现，取决于具体的系统。但是软件实现的观察点会导致程序运行很慢，使用时需注意。参见[gdb手册](https://sourceware.org/gdb/onlinedocs/gdb/Set-Watchpoints.html).
 
 如果系统支持硬件观测的话，当设置观测点是会打印如下信息：
 	Hardware watchpoint num: expr
-	
+
  如果不想用硬件观测点的话可如下设置：
     set can-use-hw-watchpoints
-    
+
 ## 查看断点
-列出当前所设置了的所有观察点：    
-info watchpoints    
+列出当前所设置了的所有观察点：
+info watchpoints
 
 watch 所设置的断点也可以用控制断点的命令来控制。如 disable、enable、delete等
 

--- a/src/set-watchpoint.md
+++ b/src/set-watchpoint.md
@@ -17,8 +17,7 @@
 	int main(int argc, char* argv[])
 	{
 	        pthread_t t1;
-            char thread_name[] = "Thread 1";
-	        pthread_create(&t1, NULL, thread1_func, thread_name);
+	        pthread_create(&t1, NULL, thread1_func, NULL);
 
 	        sleep(1000);
 	        return 0;


### PR DESCRIPTION
1. 新增“打印所有线程的堆栈信息”
2. 需要传入一个void *而给如一个const void *
```
tmp.cpp: In function 'int main(int, char**)':
tmp.cpp:19: error: invalid conversion from 'const void*' to 'void*'
tmp.cpp:19: error:   initializing argument 4 of 'int pthread_create(pthread_t*, const pthread_attr_t*, void* (*)(void*), void*)'
```

